### PR TITLE
⚡ Bolt: Optimize redundant C_Map API calls in CheckDistance loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-19 - Avoid Redundant Blizzard API Calls in Loops
+**Learning:** Frequent polling loops (e.g., 4Hz routing ticker) should avoid redundant calls to expensive external APIs like `C_Map.GetBestMapForUnit("player")` and `C_Map.GetPlayerMapPosition(...)`. These were being called multiple times per tick.
+**Action:** Pass pre-calculated results of API calls as arguments to helper functions, so the calls are made only once per tick. This reduces CPU time and possible stuttering.

--- a/Core.lua
+++ b/Core.lua
@@ -366,11 +366,20 @@ local function IsMapOrChild(currentID, targetID)
     return isChild
 end
 
-function ADW.GetBestStepIndex(route)
+function ADW.GetBestStepIndex(route, currentMapID, pos)
     if not route then return 1 end
-    local currentMapID = C_Map.GetBestMapForUnit("player")
-    if not currentMapID then return 1 end
-    local pos = C_Map.GetPlayerMapPosition(currentMapID, "player")
+
+    -- Use provided map ID and position if passed (performance optimization),
+    -- otherwise fetch them via Blizzard API.
+    if not currentMapID then
+        currentMapID = C_Map.GetBestMapForUnit("player")
+        if not currentMapID then return 1 end
+    end
+
+    if not pos and pos ~= false then
+        pos = C_Map.GetPlayerMapPosition(currentMapID, "player")
+    end
+
     local currentCont = ADW.GetMapContinent(currentMapID)
     
     local bestIdx = currentStepIndex
@@ -520,7 +529,7 @@ local function CheckDistance()
     local pos = C_Map.GetPlayerMapPosition(currentMapID, "player")
     if debugMode then Print(string.format("DEBUG: Map: %d | Step: %d", currentMapID, currentStepIndex)) end
     
-    local bestIdx = ADW.GetBestStepIndex(activeRoute)
+    local bestIdx = ADW.GetBestStepIndex(activeRoute, currentMapID, pos)
     if bestIdx > currentStepIndex then
         -- Forward-skip immunity: Don't allow SmartSync to jump forward
         -- within 8 seconds of a step advance. This prevents portal transitions


### PR DESCRIPTION
💡 What: Refactored `ADW.GetBestStepIndex` to optionally accept `currentMapID` and `pos`. Passed pre-calculated values from the `CheckDistance` 4Hz loop.
🎯 Why: `CheckDistance` ticks 4 times per second. Both it and `ADW.GetBestStepIndex` were redundantly calling expensive Blizzard APIs (`C_Map.GetBestMapForUnit` and `C_Map.GetPlayerMapPosition`).
📊 Impact: Reduces C_Map API calls during routing by 50%, saving CPU cycles and reducing potential micro-stutters during heavy client load.
🔬 Measurement: Can be verified by running the addon in debug mode (`/adw debug`) and profiling the execution time of `CheckDistance` or checking the call frequency of the mocked Blizzard API.

---
*PR created automatically by Jules for task [8954207758001900357](https://jules.google.com/task/8954207758001900357) started by @MikeO7*