### PR TITLE
🎨 Palette: Add tooltips to control bar buttons for better discoverability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-28 - Exposing Hidden Keyboard Interactions
+**Learning:** Users often miss hidden interactions like Shift-drag to move HUD elements unless explicitly informed. While the statusFrame had this hint in a tooltip, the control bar buttons (autoBtn/menuBtn) did not, leaving their draggable nature undiscoverable.
+**Action:** Always add `OnEnter` tooltips with clear text and keyboard hints for elements that support complex or hidden interactions like Shift-drag.

--- a/Core.lua
+++ b/Core.lua
@@ -318,6 +318,24 @@ menuBtn:SetScript("OnDragStop", function()
     if AutoDungeonWaypointDB then AutoDungeonWaypointDB.ToggleButtonPos = { point, relPoint, x, y } end
 end)
 
+autoBtn:SetScript("OnEnter", function(self)
+    GameTooltip_SetDefaultAnchor(GameTooltip, self)
+    GameTooltip:SetText("Toggle Auto-Routing", 0.0, 0.75, 1.0)
+    GameTooltip:AddLine("Click to enable/disable automatic dungeon detection.", 1, 1, 1, true)
+    GameTooltip:AddLine("Hold |cFFFFD100Shift|r and drag to move.", 1, 1, 1, true)
+    GameTooltip:Show()
+end)
+autoBtn:SetScript("OnLeave", GameTooltip_Hide)
+
+menuBtn:SetScript("OnEnter", function(self)
+    GameTooltip_SetDefaultAnchor(GameTooltip, self)
+    GameTooltip:SetText("Route List", 0.0, 0.75, 1.0)
+    GameTooltip:AddLine("Click to view and manually start routes.", 1, 1, 1, true)
+    GameTooltip:AddLine("Hold |cFFFFD100Shift|r and drag to move.", 1, 1, 1, true)
+    GameTooltip:Show()
+end)
+menuBtn:SetScript("OnLeave", GameTooltip_Hide)
+
 function UpdateToggleButton()
     if not AutoDungeonWaypointDB then return end
     if AutoDungeonWaypointDB.AutoRouteEnabled then


### PR DESCRIPTION
💡 What: Added tooltips to the autoBtn and menuBtn control bar buttons.
🎯 Why: Users often miss hidden interactions like Shift-drag to move HUD elements unless explicitly informed. While the statusFrame had this hint in a tooltip, the control bar buttons did not, leaving their draggable nature undiscoverable.
📸 Before/After: N/A (Tooltips added)
♿ Accessibility: Improves discoverability of existing hidden functionality.

---
*PR created automatically by Jules for task [11183008102067641630](https://jules.google.com/task/11183008102067641630) started by @MikeO7*