### PR TITLE
🎨 Palette: Add explicit interaction tooltips to minimap icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-01-28 - Exposing Hidden Keyboard Interactions
 **Learning:** Users often miss hidden interactions like Shift-drag to move HUD elements unless explicitly informed. While the statusFrame had this hint in a tooltip, the control bar buttons (autoBtn/menuBtn) did not, leaving their draggable nature undiscoverable.
 **Action:** Always add `OnEnter` tooltips with clear text and keyboard hints for elements that support complex or hidden interactions like Shift-drag.
+
+## 2025-01-28 - Discoverability for LDB/Minimap Icons
+**Learning:** Minimap icons or LDB (LibDataBroker) data objects often support multiple interactions like right-click or middle-click, but these actions are completely invisible to the user. Without explicit tooltips, users miss out on quick toggles and shortcuts.
+**Action:** Always document hidden interaction methods (like Right-Click or Middle-Click) directly inside the `OnTooltipShow` method of minimap icons and other interactive data broker objects.

--- a/Core.lua
+++ b/Core.lua
@@ -869,6 +869,9 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
                 OnTooltipShow = function(tooltip)
                     tooltip:SetText("Auto Dungeon Waypoint", 0.0, 0.75, 1.0)
                     if activeRoute then tooltip:AddLine("Active: " .. (ADW.RouteNames[activeRouteKey] or activeRouteKey)) end
+                    tooltip:AddLine(" ")
+                    tooltip:AddLine("|cFFFFD100Left-Click:|r Open route menu", 1, 1, 1)
+                    tooltip:AddLine("|cFFFFD100Right-Click:|r Toggle auto-routing", 1, 1, 1)
                 end,
             })
             LDBIcon:Register("AutoDungeonWaypoint", adwBroker, AutoDungeonWaypointDB.MinimapIcon)


### PR DESCRIPTION
💡 **What**: Added explicit tooltips for Left-Click and Right-Click interactions to the minimap (LDB) icon.
🎯 **Why**: Minimap icons and LibDataBroker objects often have hidden interaction methods (like Right-Click to toggle auto-routing) that are completely invisible to the user. Without explicit tooltips, users miss out on quick toggles and shortcuts.
📸 **Before/After**: The tooltip now clearly displays: `Left-Click: Open route menu` and `Right-Click: Toggle auto-routing`.
♿ **Accessibility**: Improves interaction discoverability for all users, eliminating the need to guess or memorize hidden functionalities.

---
*PR created automatically by Jules for task [15762404800808874796](https://jules.google.com/task/15762404800808874796) started by @MikeO7*