### PR TITLE
🎨 Palette: Add quick mouse actions to cancel active route

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,7 +1,3 @@
-## 2025-01-28 - Exposing Hidden Keyboard Interactions
-**Learning:** Users often miss hidden interactions like Shift-drag to move HUD elements unless explicitly informed. While the statusFrame had this hint in a tooltip, the control bar buttons (autoBtn/menuBtn) did not, leaving their draggable nature undiscoverable.
-**Action:** Always add `OnEnter` tooltips with clear text and keyboard hints for elements that support complex or hidden interactions like Shift-drag.
-
-## 2025-01-28 - Discoverability for LDB/Minimap Icons
-**Learning:** Minimap icons or LDB (LibDataBroker) data objects often support multiple interactions like right-click or middle-click, but these actions are completely invisible to the user. Without explicit tooltips, users miss out on quick toggles and shortcuts.
-**Action:** Always document hidden interaction methods (like Right-Click or Middle-Click) directly inside the `OnTooltipShow` method of minimap icons and other interactive data broker objects.
+## 2026-03-24 - Explicit Hidden Mouse Interactions
+**Learning:** Hidden mouse interactions like Right-Click or Middle-Click on HUD elements and minimap icons are not easily discoverable by users unless explicitly documented in their respective tooltips.
+**Action:** Always document hidden interactions directly inside the `OnEnter` or `OnTooltipShow` methods of UI elements to ensure discoverability.

--- a/Core.lua
+++ b/Core.lua
@@ -169,9 +169,18 @@ function ADW_Stop_Binding()
     end
 end
 
+statusFrame:SetScript("OnMouseUp", function(self, button)
+    if button == "RightButton" and activeRoute then
+        ADW_Stop_Binding()
+    end
+end)
+
 statusFrame:SetScript("OnEnter", function(self)
     GameTooltip_SetDefaultAnchor(GameTooltip, self)
     GameTooltip:SetText("Navigation HUD", 0.0, 0.75, 1.0)
+    if activeRoute then
+        GameTooltip:AddLine("|cFFFFD100Right-Click:|r Cancel route", 1, 1, 1, true)
+    end
     GameTooltip:AddLine("Hold |cFFFFD100Shift|r and drag to move.", 1, 1, 1, true)
     GameTooltip:Show()
 end)
@@ -869,7 +878,8 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
                                 end
                             end)
                         end
-                    elseif button == "RightButton" then ADW.ToggleAutoRoute() end
+                    elseif button == "RightButton" then ADW.ToggleAutoRoute()
+                    elseif button == "MiddleButton" then ADW_Stop_Binding() end
                 end,
                 OnTooltipShow = function(tooltip)
                     tooltip:SetText("Auto Dungeon Waypoint", 0.0, 0.75, 1.0)
@@ -877,6 +887,7 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
                     tooltip:AddLine(" ")
                     tooltip:AddLine("|cFFFFD100Left-Click:|r Open route menu", 1, 1, 1)
                     tooltip:AddLine("|cFFFFD100Right-Click:|r Toggle auto-routing", 1, 1, 1)
+                    if activeRoute then tooltip:AddLine("|cFFFFD100Middle-Click:|r Cancel route", 1, 1, 1) end
                 end,
             })
             LDBIcon:Register("AutoDungeonWaypoint", adwBroker, AutoDungeonWaypointDB.MinimapIcon)


### PR DESCRIPTION
💡 What: Added quick mouse-click actions to cancel an active route. Users can now Right-Click the status frame (HUD) or Middle-Click the minimap LDB icon to stop auto-routing without typing `/adw stop`. Tooltips have also been updated to explicitly reveal these hidden interactions.
🎯 Why: Improves discoverability and ease of use. Users previously had to type out a slash command to stop a route midway through, which is disruptive to gameplay.
📸 Before/After: Visual changes limited to tooltips (adds `Right-Click: Cancel route` and `Middle-Click: Cancel route` dynamically).
♿ Accessibility: Provides alternative interaction models that don't rely solely on keyboard text input, improving overall usability and efficiency for players who prefer mouse navigation.

---
*PR created automatically by Jules for task [799834209045389966](https://jules.google.com/task/799834209045389966) started by @MikeO7*