### PR TITLE
⚡ Bolt: Optimize LFG callbacks to prevent micro-stutters

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,7 @@
 ## 2024-05-20 - Cache string processing in frequent loops
 **Learning:** Performing string manipulation functions like `lower` and `gsub` inside loops running on repetitive event triggers (e.g. `LFG_LIST_ACTIVE_ENTRY_UPDATE`) creates unnecessary string allocations. This generates garbage for the Lua garbage collector and can result in micro-stutters.
 **Action:** Cache the resulting strings from repeated parsing operations (like mapping an unknown LFG activity ID) and early-return if the result is already known to prevent redundant text matching.
+
+## 2024-05-21 - Avoid Unnecessary Garbage in Frequent Callbacks
+**Learning:** High-frequency event handlers, such as `LFG_LIST_ACTIVE_ENTRY_UPDATE` or `ProcessActivityID`, may trigger many times a second. Performing string concatenation inside these callbacks generates useless string allocations for the Lua garbage collector and can result in micro-stutters.
+**Action:** Remove or conditionally wrap debug logging and string-building inside extremely frequent event handlers or data processors. Additionally, order `return` or short-circuit checks properly to skip heavy operations (like `IsInInstance`) if already cached or known.

--- a/Core.lua
+++ b/Core.lua
@@ -832,17 +832,17 @@ end
 function ADW.ProcessActivityID(activityID, isSilent)
     if not activityID then return end
     
+    local routeKey = ADW.LFGToRoute[activityID]
+
+    -- If we've already cached that this ID has no matching route, skip parsing
+    if routeKey == false then return end
+
     -- Prevent auto-routing if already inside a dungeon or raid
     local _, instanceType = IsInInstance()
     if instanceType == "party" or instanceType == "raid" then
         LogInfo("ProcessActivityID: Already in instance (" .. instanceType .. "), skipping.")
         return
     end
-
-    local routeKey = ADW.LFGToRoute[activityID]
-
-    -- If we've already cached that this ID has no matching route, skip parsing
-    if routeKey == false then return end
 
     LogInfo("ProcessActivityID: ID=" .. tostring(activityID) .. " Key=" .. tostring(routeKey))
 
@@ -973,7 +973,6 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     if event == "LFG_LIST_ACTIVE_ENTRY_UPDATE" then
         if AutoDungeonWaypointDB.AutoRouteEnabled then
             local activeEntry = C_LFGList.GetActiveEntryInfo()
-            LogInfo("LFG_LIST_ACTIVE_ENTRY_UPDATE: Found=" .. tostring(activeEntry ~= nil))
             if activeEntry and activeEntry.activityIDs then
                 for _, id in ipairs(activeEntry.activityIDs) do
                     ADW.ProcessActivityID(id)


### PR DESCRIPTION
💡 **What**:
- In `Core.lua`, moved the negative cache check (`routeKey == false`) inside `ADW.ProcessActivityID` to execute *before* the expensive `IsInInstance()` Blizzard API call.
- Removed a debug `LogInfo` statement inside the `LFG_LIST_ACTIVE_ENTRY_UPDATE` event handler that created useless string concatenations.
- Documented this Lua garbage collection and event handling learning in `.jules/bolt.md`.

🎯 **Why**: 
- `LFG_LIST_ACTIVE_ENTRY_UPDATE` fires extremely frequently (every time someone applies to, updates, or leaves a group).
- Doing string concatenation (`"Found=" .. tostring(...)`) inside this handler created unnecessary garbage for the Lua garbage collector, leading to potential micro-stutters.
- Calling `IsInInstance()` is a C-boundary API call. By short-circuiting on the cached `routeKey == false` state earlier, we skip the API call entirely for the majority of irrelevant LFG updates.

📊 **Impact**: Reduces CPU overhead and Lua memory allocations (garbage collection pressure) during high-frequency Group Finder updates.

🔬 **Measurement**: 
- Join a group in the Group Finder and observe that no errors occur.
- Run `/adw debug` to verify routing still triggers properly when a valid Activity ID is detected.

---
*PR created automatically by Jules for task [3722071188746072202](https://jules.google.com/task/3722071188746072202) started by @MikeO7*