### PR TITLE
⚡ Bolt: Prevent redundant table allocations in LFG handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2024-05-24 - Short-circuit evaluations in routing scores safely
 **Learning:** When optimizing scoring loops with branch-pruning or short-circuiting in Lua (such as `ADW.GetBestStepIndex`), ensure that threshold comparisons use `<=` (e.g., `bestScore <= 75`) instead of `<` if the algorithm relies on secondary tie-breakers (like distance comparisons) for equal scores. Strict less-than comparisons will introduce functional regressions by skipping valid tie scenarios.
 **Action:** Allow fallback scoring branch evaluation if the best score is less than *or equal* to the maximum possible score for that branch so that tie-breaker logic inside the loop body operates correctly.
+
+## 2024-05-25 - Prevent redundant table allocations in LFG handlers
+**Learning:** High-frequency event handlers like `LFG_LIST_ACTIVE_ENTRY_UPDATE` can cause micro-stutters when making redundant Blizzard API calls like `C_LFGList.GetActiveEntryInfo()`, which allocates a new table on every call even when no entry exists.
+**Action:** Add a `C_LFGList.HasActiveEntryInfo()` check before calling `C_LFGList.GetActiveEntryInfo()` to avoid unnecessary memory allocations and garbage collection overhead.

--- a/Core.lua
+++ b/Core.lua
@@ -984,6 +984,10 @@ end
 
 local function CheckInitialActivities(isSilent)
     if not AutoDungeonWaypointDB or not AutoDungeonWaypointDB.AutoRouteEnabled or isPlayerInInstance then return end
+
+    -- Performance Optimization: Check boolean HasActiveEntryInfo before GetActiveEntryInfo
+    -- to prevent redundant table allocations when no entry exists.
+    if not C_LFGList.HasActiveEntryInfo() then return end
     local activeEntry = C_LFGList.GetActiveEntryInfo()
     if activeEntry and activeEntry.activityIDs then
         for _, id in ipairs(activeEntry.activityIDs) do
@@ -1077,10 +1081,14 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     end
     if event == "LFG_LIST_ACTIVE_ENTRY_UPDATE" then
         if AutoDungeonWaypointDB.AutoRouteEnabled and not isPlayerInInstance then
-            local activeEntry = C_LFGList.GetActiveEntryInfo()
-            if activeEntry and activeEntry.activityIDs then
-                for _, id in ipairs(activeEntry.activityIDs) do
-                    ADW.ProcessActivityID(id)
+            -- Performance Optimization: Check boolean HasActiveEntryInfo before GetActiveEntryInfo
+            -- to prevent redundant table allocations and GC stutters on high-frequency events.
+            if C_LFGList.HasActiveEntryInfo() then
+                local activeEntry = C_LFGList.GetActiveEntryInfo()
+                if activeEntry and activeEntry.activityIDs then
+                    for _, id in ipairs(activeEntry.activityIDs) do
+                        ADW.ProcessActivityID(id)
+                    end
                 end
             end
         end


### PR DESCRIPTION
💡 **What:** Added `C_LFGList.HasActiveEntryInfo()` checks before calling `C_LFGList.GetActiveEntryInfo()` inside `CheckInitialActivities` and the `LFG_LIST_ACTIVE_ENTRY_UPDATE` event handler.

🎯 **Why:** `C_LFGList.GetActiveEntryInfo()` returns a dynamically allocated table. If a player was not listed in LFG, or if their entry was just removed, this API call would still execute and generate unnecessary garbage collection overhead during high-frequency event loops, leading to micro-stutters.

📊 **Impact:** Reduces redundant Lua table allocations to zero when no LFG entry is active. Since `LFG_LIST_ACTIVE_ENTRY_UPDATE` fires frequently when interacting with the group finder, this reduces GC pressure.

🔬 **Measurement:** This can be verified by profiling memory allocations in the WoW client while rapidly listing and delisting from the LFG tool, or by observing the absence of the table allocation when the player is not listed.

---
*PR created automatically by Jules for task [7498745777252017881](https://jules.google.com/task/7498745777252017881) started by @MikeO7*