### PR TITLE
⚡ Bolt: Defer table allocations in distance checking to prevent GC stutters

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -482,18 +482,27 @@ function ADW.GetBestStepIndex(route, currentMapID, pos)
             if score > bestScore then
                 bestScore = score
                 bestIdx = i
-                minDistSq = math.huge
-                if step.mapID == currentMapID then
-                    if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
-                    if pos then
-                        local dx = (pos.x - step.x) * 1000
-                        local dy = (pos.y - step.y) * 1000
-                        minDistSq = dx*dx + dy*dy
-                    end
-                end
+                minDistSq = nil -- Lazy evaluate distance only if a tie occurs
             elseif score == bestScore then
                 -- Same score? Pick by distance if exact, else keep current
                 if step.mapID == currentMapID then
+                    -- Lazy calculate previous best distance
+                    if not minDistSq then
+                        local prevStep = route[bestIdx]
+                        if prevStep and prevStep.mapID == currentMapID then
+                            if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
+                            if pos then
+                                local bdx = (pos.x - prevStep.x) * 1000
+                                local bdy = (pos.y - prevStep.y) * 1000
+                                minDistSq = bdx*bdx + bdy*bdy
+                            else
+                                minDistSq = math.huge
+                            end
+                        else
+                            minDistSq = math.huge
+                        end
+                    end
+
                     if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
                     if pos then
                         local dx = (pos.x - step.x) * 1000
@@ -688,6 +697,13 @@ local function CheckDistance()
 
     -- 3. Handle Arrival (Current step target reached)
     if currentMapID == step.mapID then
+        -- Arrival Buffer: If we just changed maps, wait 3s before allowing arrival.
+        -- Optimization: Check this BEFORE fetching map position to avoid unnecessary table allocations.
+        if now - lastMapChangeTime < 3 then
+            -- Note: Removed debug print here to prevent 4Hz spam during the 3-second buffer.
+            return
+        end
+
         if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
         if pos then
             local dx = (pos.x - step.x) * 1000
@@ -695,12 +711,6 @@ local function CheckDistance()
             local distSq = dx * dx + dy * dy
 
             if distSq < 10.0 then -- Threshold for "arrival"
-                -- Arrival Buffer: If we just changed maps, wait 3s before allowing arrival.
-                if now - lastMapChangeTime < 3 then
-                    if debugMode then Print("DEBUG: Arrival ignored (Map change buffer active)") end
-                    return
-                end
-
                 LogInfo(string.format("ARRIVAL: Step %d reached (DistSq: %.2f)", currentStepIndex, distSq))
                 if currentStepIndex < totalSteps then
                     currentStepIndex = currentStepIndex + 1


### PR DESCRIPTION
💡 **What**: Refactored the distance checking and scoring logic in `Core.lua`.
1.  Deferred the `C_Map.GetPlayerMapPosition` call in `ADW.GetBestStepIndex`'s routing score branch to only execute when an actual tie-breaker is required (`score == bestScore`), rather than executing unconditionally on the primary branch.
2.  Shifted the map-change buffer early-return check in `CheckDistance`'s polling loop to happen *before* the API position lookups are requested.

🎯 **Why**: The Blizzard API `C_Map.GetPlayerMapPosition` returns a `Vector2D` table. Because `CheckDistance` runs on a 4Hz ticker, calling this unconditionally caused micro-stutters from frequent garbage collection.

📊 **Impact**: This change entirely eliminates the table allocation during standard routing (no ties) when the player is on a matched map, except exactly when they are on the target step's map. Additionally, it eliminates 12 table allocations (4Hz * 3s) immediately following every map/zone transition.

🔬 **Measurement**: Verify with standard testing that the addon still accurately updates distance, calculates snap-backs, and detects step arrival without any feature regression, and observe reduced GC activity via profiling.

---
*PR created automatically by Jules for task [12280832427908830709](https://jules.google.com/task/12280832427908830709) started by @MikeO7*