### PR TITLE
🎨 Palette: Add human-readable keybinding names

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -257,6 +257,11 @@ function ADW.ToggleHUD(enabled)
     end
 end
 
+-- Keybinding localization strings for discoverability
+BINDING_HEADER_ADW = "Auto Dungeon Waypoint"
+BINDING_NAME_ADW_TOGGLEHUD = "Toggle Navigation HUD"
+BINDING_NAME_ADW_STOP = "Cancel Active Route"
+
 -- Global helpers for Bindings.xml
 function ADW_ToggleHUD_Binding()
     ADW.ToggleHUD()


### PR DESCRIPTION
💡 **What:** Added global strings (`BINDING_HEADER_ADW`, `BINDING_NAME_ADW_TOGGLEHUD`, `BINDING_NAME_ADW_STOP`) to `Core.lua` that map to the keybindings defined in `Bindings.xml`.
🎯 **Why:** Previously, if users visited the WoW Key Bindings interface to set hotkeys for this addon, they would see raw internal XML variable names (like `ADW_TOGGLEHUD`). Providing localized `BINDING_NAME_` variables replaces these raw IDs with clear, human-readable text.
📸 **Before/After:** Not visual in the main UI, but visible in the WoW Key Bindings interface.
♿ **Accessibility:** Significantly improves discoverability and clarity for users attempting to configure keyboard shortcuts for the addon.

---
*PR created automatically by Jules for task [18321100282016731254](https://jules.google.com/task/18321100282016731254) started by @MikeO7*