### PR TITLE
⚡ Bolt: Cache GetPlayerMapPosition to reduce GC stutters

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 ## 2024-05-25 - Prevent redundant table allocations in LFG handlers
 **Learning:** High-frequency event handlers like `LFG_LIST_ACTIVE_ENTRY_UPDATE` can cause micro-stutters when making redundant Blizzard API calls like `C_LFGList.GetActiveEntryInfo()`, which allocates a new table on every call even when no entry exists.
 **Action:** Add a `C_LFGList.HasActiveEntryInfo()` check before calling `C_LFGList.GetActiveEntryInfo()` to avoid unnecessary memory allocations and garbage collection overhead.
+## 2026-03-30 - Cache Table-Allocating Map Position APIs
+**Learning:** Calling `C_Map.GetPlayerMapPosition` creates a new table on every execution. In high-frequency 4Hz loops, this causes redundant memory allocations and garbage collection micro-stutters when the player is idle or moving slightly.
+**Action:** Use the global `UnitPosition("player")` (which returns primitive, unboxed numerical world coordinates) to track the exact player state and conditionally return a cached `C_Map.GetPlayerMapPosition` result instead of calling the API repeatedly when the world coordinates haven't changed.

--- a/Core.lua
+++ b/Core.lua
@@ -421,6 +421,25 @@ end
 -- ============================================================================
 -- SmartSync Engine
 -- ============================================================================
+
+ADW.MapPosCache = { x = nil, y = nil, inst = nil, map = nil, pos = nil }
+function ADW.GetPlayerMapPosition(mapID)
+    if not mapID then return nil end
+    local y, x, _, instanceID = UnitPosition("player")
+    if not x then return C_Map.GetPlayerMapPosition(mapID, "player") end
+
+    if x == ADW.MapPosCache.x and y == ADW.MapPosCache.y and instanceID == ADW.MapPosCache.inst and mapID == ADW.MapPosCache.map then
+        return ADW.MapPosCache.pos
+    end
+
+    ADW.MapPosCache.x = x
+    ADW.MapPosCache.y = y
+    ADW.MapPosCache.inst = instanceID
+    ADW.MapPosCache.map = mapID
+    ADW.MapPosCache.pos = C_Map.GetPlayerMapPosition(mapID, "player")
+    return ADW.MapPosCache.pos
+end
+
 ADW.ContinentCache = {}
 function ADW.GetMapContinent(mapID)
     if not mapID then return nil end
@@ -500,7 +519,7 @@ function ADW.GetBestStepIndex(route, currentMapID, pos)
                     if not minDistSq then
                         local prevStep = route[bestIdx]
                         if prevStep and prevStep.mapID == currentMapID then
-                            if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
+                            if not posFetched then pos = ADW.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
                             if pos then
                                 local bdx = (pos.x - prevStep.x) * 1000
                                 local bdy = (pos.y - prevStep.y) * 1000
@@ -513,7 +532,7 @@ function ADW.GetBestStepIndex(route, currentMapID, pos)
                         end
                     end
 
-                    if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
+                    if not posFetched then pos = ADW.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
                     if pos then
                         local dx = (pos.x - step.x) * 1000
                         local dy = (pos.y - step.y) * 1000
@@ -689,7 +708,7 @@ local function CheckDistance()
             -- Buffer: If we are still very close to the previous step's location, stay on the current step.
             local priorStep = activeRoute[currentStepIndex - 1]
             if priorStep and priorStep.mapID == currentMapID then
-                if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
+                if not posFetched then pos = ADW.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
                 if pos then
                     local dx = (pos.x - priorStep.x) * 1000
                     local dy = (pos.y - priorStep.y) * 1000
@@ -716,7 +735,7 @@ local function CheckDistance()
             return
         end
 
-        if not posFetched then pos = C_Map.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
+        if not posFetched then pos = ADW.GetPlayerMapPosition(currentMapID, "player"); posFetched = true end
         if pos then
             local dx = (pos.x - step.x) * 1000
             local dy = (pos.y - step.y) * 1000
@@ -877,7 +896,7 @@ SlashCmdList["AUTODUNGEONWAYPOINT"] = function(msg)
     elseif cmd == "nearest" then
         local currentMapID = C_Map.GetBestMapForUnit("player")
         if not currentMapID then return end
-        local pos = C_Map.GetPlayerMapPosition(currentMapID, "player")
+        local pos = ADW.GetPlayerMapPosition(currentMapID, "player")
         local bestKey, bestDist = nil, math.huge
         for key, route in pairs(ADW.Routes) do
             local step1 = route[1]
@@ -913,7 +932,7 @@ SlashCmdList["AUTODUNGEONWAYPOINT"] = function(msg)
     elseif cmd == "pos" then
         local currentMapID = C_Map.GetBestMapForUnit("player")
         if currentMapID then
-            local pos = C_Map.GetPlayerMapPosition(currentMapID, "player")
+            local pos = ADW.GetPlayerMapPosition(currentMapID, "player")
             if pos then
                 ForcePrint(string.format("Position: mapID=%d  x=%.4f  y=%.4f", currentMapID, pos.x, pos.y))
             else


### PR DESCRIPTION
**What:**
Introduced a caching wrapper `ADW.GetPlayerMapPosition(mapID)` around `C_Map.GetPlayerMapPosition(mapID, "player")` in `Core.lua`. The cache uses `UnitPosition("player")` (which returns unboxed numbers) to determine if the player has actually moved. 

**Why:**
`C_Map.GetPlayerMapPosition` dynamically allocates a new `Vector2D` table on every call. When executing inside the 4Hz distance-checking polling loop, this causes continuous memory allocations resulting in garbage collection micro-stutters when the player is idle or minimally moving.

**Impact:**
Eliminates redundant table allocations inside the 4Hz loop when the player's world position hasn't changed, significantly reducing garbage generation and micro-stutters.

**Measurement:**
Verified via code inspection and Lua parser validation. It can be measured in-game by profiling Lua memory allocation rates while standing still with an active route.

---
*PR created automatically by Jules for task [18291357592585350630](https://jules.google.com/task/18291357592585350630) started by @MikeO7*