### PR TITLE
🎨 Palette: Add explicit close button to Navigation HUD

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-04-03 - Dynamic Status Rendering
 **Learning:** State-dependent UI visuals (like portal icons and text prefixes) should be derived dynamically during render, rather than relying on one-time event injections, to prevent context loss on UI reload or toggle.
 **Action:** Always compute derived state at the time of rendering when updating HUD elements.
+
+## 2026-04-05 - Explicit Visual Controls Over Hidden Interactions
+**Learning:** While tooltips can document hidden interactions (like right-clicking a tracker frame to dismiss it), relying solely on hidden interactions reduces usability and discoverability for users who don't read tooltips.
+**Action:** Always provide an explicit, recognizable visual control (such as a standard `[X]` close button) for common destructive/dismissive actions, while keeping the hidden interaction as a power-user shortcut.

--- a/Core.lua
+++ b/Core.lua
@@ -225,6 +225,18 @@ stepText:SetWordWrap(true)
 stepText:SetText("")
 statusFrame:Hide()
 
+local closeBtn = CreateFrame("Button", nil, statusFrame, "UIPanelCloseButton")
+closeBtn:SetSize(24, 24)
+closeBtn:SetPoint("TOPRIGHT", statusFrame, "TOPRIGHT", -4, -4)
+closeBtn:SetScript("OnClick", function()
+    if activeRoute then
+        ADW_Stop_Binding()
+    else
+        HideStatusFrame()
+    end
+end)
+ADW.SetTooltip(closeBtn, "Close", "Dismiss the navigation HUD.\nIf a route is active, it will be cancelled.")
+
 function ADW.ToggleHUD(enabled)
     local db = AutoDungeonWaypointDB
     if enabled == nil then

--- a/modify.py
+++ b/modify.py
@@ -1,0 +1,25 @@
+import sys
+
+with open('Core.lua', 'r') as f:
+    content = f.read()
+
+search_str = """
+local closeBtn = CreateFrame("Button", nil, statusFrame, "UIPanelButtonTemplate")
+closeBtn:SetSize(24, 24)
+closeBtn:SetPoint("TOPRIGHT", statusFrame, "TOPRIGHT", -4, -4)
+closeBtn:SetText("X")
+"""
+
+replace_str = """
+local closeBtn = CreateFrame("Button", nil, statusFrame, "UIPanelCloseButton")
+closeBtn:SetSize(24, 24)
+closeBtn:SetPoint("TOPRIGHT", statusFrame, "TOPRIGHT", -4, -4)
+"""
+
+if search_str in content:
+    content = content.replace(search_str, replace_str)
+    with open('Core.lua', 'w') as f:
+        f.write(content)
+    print("Replaced successfully")
+else:
+    print("Could not find search string")


### PR DESCRIPTION
💡 **What:** Added an explicit `[X]` close button (using `UIPanelCloseButton`) to the top-right corner of the Navigation HUD.
🎯 **Why:** To significantly improve UX discoverability. Dismissing the HUD previously relied entirely on a hidden right-click interaction.
📸 **Before/After:** (Visual change - standard X button added to the top right of the status frame).
♿ **Accessibility:** Provides a recognizable, visual, standard interaction method for dismissing the frame, reducing reliance on hidden power-user shortcuts.

---
*PR created automatically by Jules for task [6154406316078288626](https://jules.google.com/task/6154406316078288626) started by @MikeO7*