### PR TITLE
🎨 Palette: Dynamic UI feedback for dependent configuration settings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2024-04-06 - [Context Menu & Addon Compartment Active State Discoverability]
 **Learning:** In World of Warcraft addons, context menus and addon compartment tooltips often hide active states or require slash commands for cancellation, leading to poor discoverability. Modifying the generated menu to dynamically display an `(Active)` label and providing a dedicated "Cancel Active Route" button (and advertising the Middle-Click shortcut in tooltips) significantly improves the interaction loop.
 **Action:** When implementing WoW UI context menus or compartment dropdowns, always ensure that any active system state is visually apparent in the menu items and that immediate, explicit control options (like cancel/stop) are injected directly into the UI rather than relying on slash commands.
+
+## 2024-04-07 - Dependent Configuration State Feedback
+**Learning:** Configuration panels containing dependent sub-settings (e.g., "Compact HUD" needing "Show Navigation HUD") often leave users confused if the child setting is toggled while the parent is off and produces no effect.
+**Action:** Always visually indent dependent child settings, and dynamically disable (`SetEnabled(false)`) and dim (`SetAlpha(0.5)`) them when their parent setting is disabled to clearly indicate their inactive state.

--- a/Core.lua
+++ b/Core.lua
@@ -1030,13 +1030,24 @@ local function CreateOptionsPanel()
         "Compact HUD", "Hides the instructional text to save screen space.", function()
             if AutoDungeonWaypointDB.ShowStatusFrame then UpdateStatusFrame("HUD Preview", "This is how the HUD looks.", 1, 5) end
         end)
-    compactCheck:SetPoint("TOPLEFT", hudCheck, "BOTTOMLEFT", 0, -8)
+    compactCheck:SetPoint("TOPLEFT", hudCheck, "BOTTOMLEFT", 20, -4)
+
+    hudCheck:HookScript("OnClick", function(self)
+        local isEnabled = self:GetChecked()
+        compactCheck:SetEnabled(isEnabled)
+        if isEnabled then compactCheck:SetAlpha(1) else compactCheck:SetAlpha(0.5) end
+    end)
+    compactCheck:HookScript("OnShow", function(self)
+        local isEnabled = AutoDungeonWaypointDB.ShowStatusFrame ~= false
+        self:SetEnabled(isEnabled)
+        if isEnabled then self:SetAlpha(1) else self:SetAlpha(0.5) end
+    end)
 
     local controlBarCheck = ADW.CreateConfigCheckbox(panel, "Show Control Bar", "ShowControlBar",
         "Control Bar", "Shows the movable bar with Auto-Routing toggle and List buttons.", function(val)
             if val then controlBar:Show() else controlBar:Hide() end
         end)
-    controlBarCheck:SetPoint("TOPLEFT", compactCheck, "BOTTOMLEFT", 0, -8)
+    controlBarCheck:SetPoint("TOPLEFT", compactCheck, "BOTTOMLEFT", -20, -8)
 
     local chatCheck = ADW.CreateConfigCheckbox(panel, "Enable Chat Announcements", "ShowChatText",
         "Chat Announcements", "Shows text in your chat box when a route starts or a step advances.",


### PR DESCRIPTION
💡 What: Added visual indenting and dynamic enabled/dimmed state to the "Compact HUD" setting based on its parent "Navigation HUD" setting.
🎯 Why: Configuration panels with dependent sub-settings often leave users confused if the child setting is toggled while the parent is off. Visually indicating the dependency and dynamically updating the active state clarifies the interaction.
📸 Before/After: Visual placement shift `+20` on X-axis for "Compact HUD" and dimming `Alpha` when parent is unchecked.
♿ Accessibility: Provides immediate visual feedback indicating control availability.

---
*PR created automatically by Jules for task [10745514916555019288](https://jules.google.com/task/10745514916555019288) started by @MikeO7*