### PR TITLE
🎨 Palette: Add multi-step route progress bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-04-07 - Dependent Configuration State Feedback
 **Learning:** Configuration panels containing dependent sub-settings (e.g., "Compact HUD" needing "Show Navigation HUD") often leave users confused if the child setting is toggled while the parent is off and produces no effect.
 **Action:** Always visually indent dependent child settings, and dynamically disable (`SetEnabled(false)`) and dim (`SetAlpha(0.5)`) them when their parent setting is disabled to clearly indicate their inactive state.
+
+## 2026-04-08 - Multi-step Process Progress Indicator
+**Learning:** For multi-step routing, users may lack context regarding their progression and how many steps are remaining, leading to friction. Adding a visible progress indicator provides immediate context and improves confidence in multi-step workflows.
+**Action:** Always include a visual progress indicator (like a progress bar) when users are navigating through a multi-step sequence or wizard.

--- a/Core.lua
+++ b/Core.lua
@@ -232,6 +232,14 @@ stepText:SetPoint("RIGHT", statusFrame, "RIGHT", -10, 0)
 stepText:SetJustifyH("LEFT")
 stepText:SetWordWrap(true)
 stepText:SetText("")
+
+local progressBar = CreateFrame("StatusBar", "ADWProgressBar", statusFrame)
+progressBar:SetPoint("BOTTOMLEFT", statusFrame, "BOTTOMLEFT", 6, 6)
+progressBar:SetPoint("BOTTOMRIGHT", statusFrame, "BOTTOMRIGHT", -6, 6)
+progressBar:SetHeight(4)
+progressBar:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
+progressBar:SetStatusBarColor(0, 0.75, 1, 0.8) -- Cyan
+progressBar:Hide()
 statusFrame:Hide()
 
 local closeBtn = CreateFrame("Button", nil, statusFrame, "UIPanelCloseButton")
@@ -439,6 +447,14 @@ function UpdateStatusFrame(title, desc, current, total, isPortal)
         statusFrame:SetHeight(70)
     end
     
+    if total and total > 0 then
+        progressBar:SetMinMaxValues(0, total)
+        progressBar:SetValue(current or 0)
+        progressBar:Show()
+    else
+        progressBar:Hide()
+    end
+
     if not statusFrame:IsShown() then ShowStatusFrame() end
 end
 


### PR DESCRIPTION
**💡 What:** Added a cyan visual progress bar (`StatusBar`) to the bottom of the Navigation HUD that tracks progression through multi-step routes.
**🎯 Why:** Users navigating multi-step routing paths may lack context on how many steps are remaining, leading to friction. A visual progress indicator provides immediate context and improves confidence in the workflow.
**📸 Before/After:** Before: Only step text like "Step 1/3". After: A sleek, 4px tall cyan progress bar anchored to the bottom of the status frame.
**♿ Accessibility:** Improves cognitive accessibility by providing an explicit, visual progression state rather than relying solely on reading text counters.

---
*PR created automatically by Jules for task [13938463675398008244](https://jules.google.com/task/13938463675398008244) started by @MikeO7*