### PR TITLE
🎨 Palette: Expand Checkbox Hit Areas

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,7 @@
 ## 2026-04-08 - Multi-step Process Progress Indicator
 **Learning:** For multi-step routing, users may lack context regarding their progression and how many steps are remaining, leading to friction. Adding a visible progress indicator provides immediate context and improves confidence in multi-step workflows.
 **Action:** Always include a visual progress indicator (like a progress bar) when users are navigating through a multi-step sequence or wizard.
+
+## 2024-04-09 - Expanded Checkbox Hit Areas
+**Learning:** In standard UI frameworks (like WoW's `UICheckButtonTemplate`), the associated text labels often do not inherently expand the component's clickable area, violating WCAG principles for target sizing and causing accessibility friction for users relying on pointer precision.
+**Action:** Always verify if text labels are enclosed within the interactive hit area boundaries. Use `SetHitRectInsets` (or equivalent CSS/HTML `<label>` wrapping) to extend the clickable target zone across the descriptive text.

--- a/Core.lua
+++ b/Core.lua
@@ -181,7 +181,13 @@ end
 
 function ADW.CreateConfigCheckbox(panel, label, dbKey, tooltipTitle, tooltipBody, callback)
     local check = CreateFrame("CheckButton", "ADW_"..dbKey.."_Check", panel, "UICheckButtonTemplate")
-    _G[check:GetName() .. "Text"]:SetText(label)
+    local textLabel = _G[check:GetName() .. "Text"]
+    textLabel:SetText(label)
+
+    -- Expand hit area to include text
+    local textWidth = textLabel:GetStringWidth() or 100
+    check:SetHitRectInsets(0, -textWidth, 0, 0)
+
     check:SetScript("OnClick", function(self)
         AutoDungeonWaypointDB[dbKey] = self:GetChecked()
         if callback then callback(self:GetChecked()) end


### PR DESCRIPTION
**💡 What:** Expanded the clickable hit area of configuration checkboxes to include their descriptive text labels.
**🎯 Why:** Standard `UICheckButtonTemplate` checkboxes in WoW only register clicks exactly on the tiny square graphic. By extending the hit-box across the text, users no longer need exact pointer precision to toggle settings. 
**📸 Before/After:** N/A (Interaction change)
**♿ Accessibility:** Improves target sizing (WCAG 2.5.5) for users relying on mouse inputs by drastically increasing the interactive area of the configuration form controls.

---
*PR created automatically by Jules for task [1556353485735642534](https://jules.google.com/task/1556353485735642534) started by @MikeO7*