### PR TITLE
⚡ Bolt: Optimize CheckDistance with early return for idle players

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -40,3 +40,7 @@
 ## 2026-03-30 - Cache Table-Allocating Map Position APIs
 **Learning:** Calling `C_Map.GetPlayerMapPosition` creates a new table on every execution. In high-frequency 4Hz loops, this causes redundant memory allocations and garbage collection micro-stutters when the player is idle or moving slightly.
 **Action:** Use the global `UnitPosition("player")` (which returns primitive, unboxed numerical world coordinates) to track the exact player state and conditionally return a cached `C_Map.GetPlayerMapPosition` result instead of calling the API repeatedly when the world coordinates haven't changed.
+
+## 2024-05-26 - Early returns for stationary loops
+**Learning:** High-frequency polling loops (like the `CheckDistance` routing tick) that perform conditional iterations and complex distance mapping can create performance overhead even when the player isn't moving.
+**Action:** When working with 4Hz position loops in WoW addons, cache the player's exact unboxed `y, x` world coordinates via `UnitPosition("player")` and map ID. Introduce an early return at the very top of the polling function if these three values exactly match the previous tick, bypassing all complex distance and map tree logic when the player is completely idle.

--- a/Core.lua
+++ b/Core.lua
@@ -22,6 +22,8 @@ local tomtomUID = nil  -- Optional TomTom waypoint UID
 local lastStepAdvance = 0 -- Timestamp of last forward step
 local lastMapChangeTime = 0
 local lastMapID = nil
+local lastPlayerX = nil
+local lastPlayerY = nil
 local isPlayerInInstance = false
 
 -- Forward declarations to prevent nil errors (SetWaypointStep, etc.)
@@ -713,6 +715,8 @@ function ClearRoute()
     totalSteps = 0
     lastStepAdvance = 0
     lastMapChangeTime = 0
+    lastPlayerX = nil
+    lastPlayerY = nil
     
     if not InCombatLockdown() then
         portalBtn:SetAttribute("macrotext", nil)
@@ -856,6 +860,14 @@ local function CheckDistance()
     local currentMapID = C_Map.GetBestMapForUnit("player")
     if not currentMapID then return end
 
+    -- Early return if player is completely stationary to avoid redundant table allocs and GC stutters
+    local currentY, currentX = UnitPosition("player")
+    if currentMapID == lastMapID and currentX == lastPlayerX and currentY == lastPlayerY then
+        return
+    end
+    lastPlayerX = currentX
+    lastPlayerY = currentY
+
     -- Update map change buffer
     if currentMapID ~= lastMapID then
         lastMapID = currentMapID
@@ -972,6 +984,8 @@ function StartRoute(routeKey, skipBroadcast)
     currentStepIndex = ADW.GetBestStepIndex(route)
     lastStepAdvance = GetTime()
     lastMapChangeTime = 0
+    lastPlayerX = nil
+    lastPlayerY = nil
     
     local dungeonName = ADW.RouteNames[routeKey] or routeKey
     local msg = GREEN .. "Starting route to " .. dungeonName .. " (" .. totalSteps .. " steps)|r"


### PR DESCRIPTION
**💡 What:** Implemented an early return mechanism in the high-frequency `CheckDistance` polling loop that tracks the unboxed primitive variables `lastPlayerX` and `lastPlayerY` (derived from `UnitPosition("player")`). 

**🎯 Why:** The `CheckDistance` function executes at 4Hz. Even when `C_Map` functions were previously optimized, the loop still redundantly traversed the `activeRoute` array and performed scoring logic/tie-breaker calculations every 0.25 seconds even when the player was completely AFK or stationary.

**📊 Impact:** Eliminates 100% of the distance/scoring logic overhead during ticks where the player is stationary, significantly reducing CPU processing weight while idle. The added variable lookups are cheap primitive comparisons.

**🔬 Measurement:** Start a route and stand completely still. Verify that standard distance tracking and routing logic correctly resumes upon movement without regressions. Validate that snap-back immunity buffers still clear as expected after transitioning maps.

---
*PR created automatically by Jules for task [14516005184729718299](https://jules.google.com/task/14516005184729718299) started by @MikeO7*