### PR TITLE
🎨 Palette: Improve UI contrast

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2024-04-09 - Expanded Checkbox Hit Areas
 **Learning:** In standard UI frameworks (like WoW's `UICheckButtonTemplate`), the associated text labels often do not inherently expand the component's clickable area, violating WCAG principles for target sizing and causing accessibility friction for users relying on pointer precision.
 **Action:** Always verify if text labels are enclosed within the interactive hit area boundaries. Use `SetHitRectInsets` (or equivalent CSS/HTML `<label>` wrapping) to extend the clickable target zone across the descriptive text.
+
+## 2026-04-10 - High Contrast for Glass UI Backgrounds
+**Learning:** Dark text (e.g., color values around 0.15 - 0.3) on nearly-black, semi-transparent "glass" UI backgrounds results in poor accessibility and unreadable text, failing WCAG contrast ratios.
+**Action:** Always ensure minimum brightness (e.g., > 0.4) for inactive or placeholder text elements rendered against dark glass frames to maintain legibility.

--- a/Core.lua
+++ b/Core.lua
@@ -491,7 +491,7 @@ if ADW.PortalLayout then
         local label = portalMap:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
         label:SetPoint("CENTER", portalMap, "CENTER", xOff, 2)
         label:SetText(slot.circle)
-        label:SetTextColor(0.25, 0.25, 0.25)
+        label:SetTextColor(0.4, 0.4, 0.4)
         slotLabels[i] = label
     end
 end
@@ -510,10 +510,10 @@ local function ShowPortalMap(routeKey)
             slotLabels[i]:SetFont("Fonts\\FRIZQT__.TTF", 22, "OUTLINE")
             activeLabel:SetText("▲ " .. slot.name)
         elseif slot.key then
-            slotLabels[i]:SetTextColor(0.3, 0.3, 0.3)
+            slotLabels[i]:SetTextColor(0.65, 0.65, 0.65)
             slotLabels[i]:SetFont("Fonts\\FRIZQT__.TTF", 16, "OUTLINE")
         else
-            slotLabels[i]:SetTextColor(0.15, 0.15, 0.15)
+            slotLabels[i]:SetTextColor(0.4, 0.4, 0.4)
             slotLabels[i]:SetFont("Fonts\\FRIZQT__.TTF", 12, "OUTLINE")
         end
     end


### PR DESCRIPTION
* 💡 What: Lightened the text color values for the inactive Timeways portal circles in `Core.lua`.
* 🎯 Why: The previous color values (0.15 and 0.3) were too dark against the semi-transparent black "glass" background, making them extremely difficult to read.
* 📸 Before/After: Visual text brightness increased from near-black to mid-grey for inactive elements.
* ♿ Accessibility: Directly addresses a WCAG color contrast issue on dark UI elements.

---
*PR created automatically by Jules for task [8044734821756868487](https://jules.google.com/task/8044734821756868487) started by @MikeO7*