### PR TITLE
🎨 Palette: Add visual feedback for drag operations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2026-04-10 - High Contrast for Glass UI Backgrounds
 **Learning:** Dark text (e.g., color values around 0.15 - 0.3) on nearly-black, semi-transparent "glass" UI backgrounds results in poor accessibility and unreadable text, failing WCAG contrast ratios.
 **Action:** Always ensure minimum brightness (e.g., > 0.4) for inactive or placeholder text elements rendered against dark glass frames to maintain legibility.
+
+## 2024-04-11 - Visual Feedback for Draggable UIs
+**Learning:** WoW frames that lack visual feedback when detached and dragged (e.g., via Shift-Click) fail to clearly indicate state changes to the user, breaking the connection between input and element response.
+**Action:** When implementing custom drag handlers (`OnDragStart`/`OnDragStop`), always include an explicit visual cue, such as decreasing element opacity (`SetAlpha(0.7)`) during the drag action, to immediately indicate active interaction.

--- a/Core.lua
+++ b/Core.lua
@@ -131,11 +131,22 @@ function ADW.MakeDraggable(frame, dbKey, parentFrame)
     frame:RegisterForDrag("LeftButton")
     
     local target = parentFrame or frame
+    local isDragging = false
+    local originalAlpha = 1.0
     frame:SetScript("OnDragStart", function() 
-        if IsShiftKeyDown() then target:StartMoving() end 
+        if IsShiftKeyDown() then
+            isDragging = true
+            originalAlpha = target:GetAlpha()
+            target:StartMoving()
+            target:SetAlpha(originalAlpha * 0.7)
+        end
     end)
     frame:SetScript("OnDragStop", function()
         target:StopMovingOrSizing()
+        if isDragging then
+            target:SetAlpha(originalAlpha)
+            isDragging = false
+        end
         if not AutoDungeonWaypointDB or not dbKey then return end
         local point, _, relPoint, x, y = target:GetPoint()
         AutoDungeonWaypointDB[dbKey] = { point, relPoint, x, y }


### PR DESCRIPTION
* 💡 **What:** Added dynamic opacity changes to `ADW.MakeDraggable` so that any draggable UI frame visually indicates when it is being moved by dropping its opacity to 70% of its original value.
* 🎯 **Why:** Previously, grabbing and dragging frames (like the Navigation HUD) provided no immediate visual feedback, leading to a disconnected feeling when interacting with the UI.
* 📸 **Before/After:** Before: Frame remains at 100% original opacity while dragged. After: Frame becomes slightly transparent while dragging, returning to its previous opacity when dropped.
* ♿ **Accessibility:** Improves visual state communication, ensuring users clearly see when an element is in an active "dragging" state.

---
*PR created automatically by Jules for task [13541277303752882215](https://jules.google.com/task/13541277303752882215) started by @MikeO7*