### PR TITLE
🎨 Palette: Improve progress context and system state visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,6 @@
 ## 2024-05-18 - Context-Aware Tooltips
 **Learning:** Single UI buttons with multi-state contexts (like the Close button on the navigation HUD) require dynamic tooltips to prevent accidental destructive actions, especially when closing the HUD also cancels an active route. Static tooltips fail to convey the current state clearly.
 **Action:** When creating multi-purpose buttons, implement dynamic `OnEnter` scripts that update the tooltip text based on the application's current state, rather than assigning a static, one-size-fits-all tooltip string.
+## 2024-05-25 - Progress Bar Context and State Discoverability
+**Learning:** For World of Warcraft addon UIs, `StatusBar` elements without a distinct background track lack visual context when nearly empty, and hiding system status (like toggle states) inside configuration panels adds unnecessary friction.
+**Action:** Enhance progress indicators by adding a dark, semi-transparent background texture (an 'empty track'), and dynamically prefix shared tooltips with the feature's current state (e.g., Auto-Routing: ON/OFF) using color coding to improve discoverability without opening menus.

--- a/Core.lua
+++ b/Core.lua
@@ -67,6 +67,11 @@ local function Print(msg)
 end
 
 local function AddSharedTooltipLines(tooltip)
+    if AutoDungeonWaypointDB then
+        local stateText = AutoDungeonWaypointDB.AutoRouteEnabled and "|cFF00FF00ON|r" or "|cFFFF0000OFF|r"
+        tooltip:AddLine("Auto-Routing: " .. stateText, 1, 1, 1)
+        tooltip:AddLine(" ")
+    end
     tooltip:AddLine("|cFFFFD100Left-Click:|r Open route menu", 1, 1, 1)
     tooltip:AddLine("|cFFFFD100Right-Click:|r Toggle auto-routing", 1, 1, 1)
 end
@@ -259,6 +264,13 @@ progressBar:SetPoint("BOTTOMRIGHT", statusFrame, "BOTTOMRIGHT", -6, 6)
 progressBar:SetHeight(4)
 progressBar:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
 progressBar:SetStatusBarColor(0, 0.75, 1, 0.8) -- Cyan
+
+local progressBg = progressBar:CreateTexture(nil, "BACKGROUND")
+progressBg:SetTexture("Interface\\TargetingFrame\\UI-StatusBar")
+progressBg:SetAllPoints()
+progressBg:SetVertexColor(0, 0, 0, 0.5)
+progressBar.bg = progressBg
+
 progressBar:Hide()
 statusFrame:Hide()
 


### PR DESCRIPTION
💡 **What:** Added a semi-transparent dark background track to the HUD progress bar and prefixed shared tooltips (LDB/minimap) with the current `AutoRouteEnabled` toggle state.

🎯 **Why:** Previously, the progress bar lacked an "empty track," making it difficult for users to gauge total progress relative to the bar's width when it was nearly empty. Additionally, users had to open the settings menu or blindly click the toggle to discover if Auto-Routing was currently active. 

♿ **Accessibility & UX:** 
- The background track creates defined spatial boundaries for the bar, significantly improving readability and visual context.
- Prefixing the state (`Auto-Routing: |cFF00FF00ON|r`) directly in the tooltip eliminates friction and increases system status discoverability without requiring users to navigate configuration panels.

---
*PR created automatically by Jules for task [17234842856226512501](https://jules.google.com/task/17234842856226512501) started by @MikeO7*