### PR TITLE
🎨 Palette: [Progress Bar Visual Context]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2024-05-18 - Context-Aware Tooltips
 **Learning:** Single UI buttons with multi-state contexts (like the Close button on the navigation HUD) require dynamic tooltips to prevent accidental destructive actions, especially when closing the HUD also cancels an active route. Static tooltips fail to convey the current state clearly.
 **Action:** When creating multi-purpose buttons, implement dynamic `OnEnter` scripts that update the tooltip text based on the application's current state, rather than assigning a static, one-size-fits-all tooltip string.
+
+## 2026-04-14 - Progress Bar Visual Context
+**Learning:** Users can misinterpret mostly-empty progress bars if the total track length is not visually distinct from the frame background.
+**Action:** Always provide a dark, semi-transparent background texture (an 'empty track') behind status bars to give visual context of the relative progress length.

--- a/Core.lua
+++ b/Core.lua
@@ -259,6 +259,11 @@ progressBar:SetPoint("BOTTOMRIGHT", statusFrame, "BOTTOMRIGHT", -6, 6)
 progressBar:SetHeight(4)
 progressBar:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
 progressBar:SetStatusBarColor(0, 0.75, 1, 0.8) -- Cyan
+
+local progressBg = progressBar:CreateTexture(nil, "BACKGROUND")
+progressBg:SetAllPoints()
+progressBg:SetColorTexture(0, 0, 0, 0.5) -- Dark semi-transparent background track
+
 progressBar:Hide()
 statusFrame:Hide()
 


### PR DESCRIPTION
💡 **What:** Added a dark, semi-transparent background track (`progressBg`) to the `ADWProgressBar` in the navigation HUD.
🎯 **Why:** Users can misinterpret mostly-empty progress bars if the total track length is not visually distinct from the frame's background. An explicit "empty track" provides immediate visual context of relative progress.
📸 **Before/After:** The progress bar previously floated on the glass background. It now has a defined dark track that the bright cyan progress bar fills.
♿ **Accessibility:** Improves visual cognition and contrast by explicitly defining the boundaries and total scale of the progress indicator.

---
*PR created automatically by Jules for task [12585972057253227338](https://jules.google.com/task/12585972057253227338) started by @MikeO7*