### PR TITLE
🎨 Palette: Dynamic Tooltip Status

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -56,3 +56,7 @@
 ## 2026-04-14 - Progress Bar Visual Context
 **Learning:** Users can misinterpret mostly-empty progress bars if the total track length is not visually distinct from the frame background.
 **Action:** Always provide a dark, semi-transparent background texture (an 'empty track') behind status bars to give visual context of the relative progress length.
+
+## 2024-05-19 - Dynamic Status Rendering in Tooltips
+**Learning:** To improve system status discoverability in World of Warcraft addons, dynamically prefix shared tooltips (such as LDB/minimap icons) with the feature's current state (e.g., Auto-Routing: ON/OFF) using color coding, eliminating the need to open configuration panels.
+**Action:** Always compute derived state at the time of rendering when updating HUD elements and tooltips.

--- a/Core.lua
+++ b/Core.lua
@@ -67,6 +67,9 @@ local function Print(msg)
 end
 
 local function AddSharedTooltipLines(tooltip)
+    local stateText = (AutoDungeonWaypointDB and AutoDungeonWaypointDB.AutoRouteEnabled) and "|cFF55FF55ON|r" or "|cFFFF5555OFF|r"
+    tooltip:AddLine("Auto-Routing: " .. stateText, 1, 1, 1)
+    tooltip:AddLine(" ")
     tooltip:AddLine("|cFFFFD100Left-Click:|r Open route menu", 1, 1, 1)
     tooltip:AddLine("|cFFFFD100Right-Click:|r Toggle auto-routing", 1, 1, 1)
 end


### PR DESCRIPTION
💡 **What:** Added the current system state (Auto-Routing: ON/OFF) to the shared tooltips in `Core.lua`.
🎯 **Why:** To improve system status discoverability. Users can now see if Auto-Routing is active at a glance without having to open the route menu or blindly toggle it.
📸 **Before/After:**
*   **Before:** Tooltip only displayed static interaction instructions (Left-Click to open menu, Right-Click to toggle).
*   **After:** Tooltip now dynamically prefixes the interaction instructions with `Auto-Routing: ON` (in green) or `Auto-Routing: OFF` (in red).
♿ **Accessibility:** This reduces cognitive load by making the system state immediately apparent through standard UI interactions (hovering over the minimap icon or LDB plugin).

---
*PR created automatically by Jules for task [10481703191911615127](https://jules.google.com/task/10481703191911615127) started by @MikeO7*