### PR TITLE
🎨 Palette: Add dynamic auto-routing status to tooltips

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1355,7 +1355,8 @@ end
 
 function ADW_OnAddonCompartmentEnter(_, button)
     GameTooltip_SetDefaultAnchor(GameTooltip, button)
-    GameTooltip:SetText("Auto Dungeon Waypoint", 0.0, 0.75, 1.0)
+    local stateText = AutoDungeonWaypointDB.AutoRouteEnabled and "|cFF55FF55[ON]|r" or "|cFFFF5555[OFF]|r"
+    GameTooltip:SetText("Auto Dungeon Waypoint " .. stateText, 0.0, 0.75, 1.0)
     if activeRoute then
         GameTooltip:AddLine("Active: " .. (ADW.RouteNames[activeRouteKey] or activeRouteKey))
     end
@@ -1488,7 +1489,8 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
                     elseif button == "MiddleButton" then ADW_Stop_Binding() end
                 end,
                 OnTooltipShow = function(tooltip)
-                    tooltip:SetText("Auto Dungeon Waypoint", 0.0, 0.75, 1.0)
+                    local stateText = AutoDungeonWaypointDB.AutoRouteEnabled and "|cFF55FF55[ON]|r" or "|cFFFF5555[OFF]|r"
+                    tooltip:SetText("Auto Dungeon Waypoint " .. stateText, 0.0, 0.75, 1.0)
                     if activeRoute then tooltip:AddLine("Active: " .. (ADW.RouteNames[activeRouteKey] or activeRouteKey)) end
                     tooltip:AddLine(" ")
                     AddSharedTooltipLines(tooltip)


### PR DESCRIPTION
💡 What: Dynamically appends the current Auto-Routing state (`[ON]` in green or `[OFF]` in red) to the tooltip title for both the minimap (LDB) icon and the Addon Compartment entry.
🎯 Why: Improves system status discoverability. Users no longer have to guess or navigate to the settings menu to know if the auto-routing feature is active.
📸 Before/After: Before, tooltips just read "Auto Dungeon Waypoint". After, they read "Auto Dungeon Waypoint [ON]" or "[OFF]".
♿ Accessibility: Uses explicit, high-contrast text strings combined with color to convey state clearly.

---
*PR created automatically by Jules for task [15503921173658627247](https://jules.google.com/task/15503921173658627247) started by @MikeO7*