### PR TITLE
Auto deploy to CurseForge on each merged PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 


### PR DESCRIPTION
This PR updates the GitHub Actions release workflow to automatically deploy the addon to CurseForge whenever changes are pushed or merged into the `main` branch. Previously, deployments were only triggered by version tags. This change ensures that `main` remains the source of truth and that the latest stable code is always available on CurseForge.

Fixes #50

---
*PR created automatically by Jules for task [72510101709625386](https://jules.google.com/task/72510101709625386) started by @MikeO7*