### PR TITLE
🎨 Palette: Improve text contrast on glass backgrounds

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -582,7 +582,7 @@ if ADW.PortalLayout then
         local label = portalMap:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
         label:SetPoint("CENTER", portalMap, "CENTER", xOff, 2)
         label:SetText(slot.circle)
-        label:SetTextColor(0.4, 0.4, 0.4)
+        label:SetTextColor(0.5, 0.5, 0.5)
         slotLabels[i] = label
     end
 end
@@ -604,7 +604,7 @@ local function ShowPortalMap(routeKey)
             slotLabels[i]:SetTextColor(0.65, 0.65, 0.65)
             slotLabels[i]:SetFont("Fonts\\FRIZQT__.TTF", 16, "OUTLINE")
         else
-            slotLabels[i]:SetTextColor(0.4, 0.4, 0.4)
+            slotLabels[i]:SetTextColor(0.5, 0.5, 0.5)
             slotLabels[i]:SetFont("Fonts\\FRIZQT__.TTF", 12, "OUTLINE")
         end
     end


### PR DESCRIPTION
💡 **What**: Increased the minimum text color brightness on the inactive slots in the portal map (from RGB `0.4, 0.4, 0.4` to `0.5, 0.5, 0.5`).
🎯 **Why**: Inactive text was too dark and hard to read against the nearly-black semi-transparent glass background of the portal map frame.
📸 **Before/After**: Visually, the inactive slots ("Skyreach", "Pit of Saron", etc) on the timeways map pop slightly more instead of getting lost in the background.
♿ **Accessibility**: Improves contrast ratio, passing minimum legibility thresholds for dark, glass backgrounds.

---
*PR created automatically by Jules for task [10315075430773137547](https://jules.google.com/task/10315075430773137547) started by @MikeO7*