### PR TITLE
Automate version bumping and production releases on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,46 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump version and tag
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: bump
+        run: |
+          # Get current version from TOC
+          VERSION=$(grep "^## Version:" AutoDungeonWaypoint.toc | awk '{print $3}')
+          echo "Current version: $VERSION"
+
+          # Increment patch version
+          # This handles x.y.z format
+          NEW_VERSION=$(echo $VERSION | awk -F. '{$NF = $NF + 1;} OFS="." {print $0}')
+          echo "New version: $NEW_VERSION"
+
+          # Update TOC file
+          sed -i "s/## Version: $VERSION/## Version: $NEW_VERSION/" AutoDungeonWaypoint.toc
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Commit and tag locally
+          git add AutoDungeonWaypoint.toc
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          git tag -a "v$NEW_VERSION" -m "v$NEW_VERSION"
+
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Package and release
         uses: BigWigsMods/packager@v2
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push changes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git push origin main --tags


### PR DESCRIPTION
Automated the release process to ensure every commit to the `main` branch results in a production release on CurseForge. This was achieved by adding a version-bumping and tagging step to the `.github/workflows/release.yml` workflow. The workflow now increments the patch version in the `.toc` file, creates a local tag, runs the packager (which identifies the tagged commit as a production release), and then pushes the changes and the tag back to the repository.

Fixes #53

---
*PR created automatically by Jules for task [4252110511947925088](https://jules.google.com/task/4252110511947925088) started by @MikeO7*