### PR TITLE
🔒 [security fix] Require confirmation for shared routes

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -102,6 +102,22 @@ local function LogWarn(msg)  Log("WARN",  msg) end
 local function LogError(msg) Log("ERROR", msg) end
 
 -- ============================================================================
+-- Popups
+-- ============================================================================
+StaticPopupDialogs["ADW_CONFIRM_ROUTE"] = {
+    text = ADDON_COLOR .. "[Auto Dungeon Waypoint]|r\n\n%s shared a route to %s.\n\nDo you want to start this route?",
+    button1 = YES,
+    button2 = NO,
+    OnAccept = function(self, data)
+        StartRoute(data.routeKey, true)
+    end,
+    timeout = 30,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+-- ============================================================================
 -- UI Helpers (DRY)
 -- ============================================================================
 function ADW.ApplyGlassAesthetic(frame, hasBorder)
@@ -1559,8 +1575,11 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
         return
     end
     if event == "CHAT_MSG_ADDON" then
-        local prefix, message, _, sender = ...
+        local prefix, message, channel, sender = ...
         if prefix ~= "ADW" or not AutoDungeonWaypointDB.AutoRouteEnabled then return end
+
+        -- Trusted channels only to prevent unauthenticated route hijacking via WHISPER/SAY/etc.
+        if channel ~= "PARTY" and channel ~= "RAID" and channel ~= "GUILD" then return end
         
         -- Midnight Resilience: Robust self-filter using UnitIsUnit (handles cross-realm name nuances)
         if UnitIsUnit(sender, "player") then return end
@@ -1568,8 +1587,8 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
         local safeSender = Ambiguate(sender, "none")
         local cmd, routeKey = strsplit(":", message, 2)
         if cmd == "ROUTE" and routeKey and ADW.Routes[routeKey] and activeRouteKey ~= routeKey then
-            Print(CYAN .. safeSender .. "|r shared a route to " .. WHITE .. (ADW.RouteNames[routeKey] or routeKey) .. "|r")
-            StartRoute(routeKey, true) -- skipBroadcast = true to prevent infinite loops
+            local dungeonName = ADW.RouteNames[routeKey] or routeKey
+            StaticPopup_Show("ADW_CONFIRM_ROUTE", CYAN .. safeSender .. "|r", WHITE .. dungeonName .. "|r", { routeKey = routeKey })
         end
     end
 end)


### PR DESCRIPTION
The `CHAT_MSG_ADDON` event handler in `Core.lua` was vulnerable to unauthenticated route hijacking. Previously, it would automatically call `StartRoute` whenever a message with the `ADW` prefix and `ROUTE` command was received, regardless of the sender or channel.

This fix implements a defense-in-depth approach:
1. **Channel Verification**: The addon now only processes `ADW` messages received via `PARTY`, `RAID`, or `GUILD` channels. Messages sent via `WHISPER`, `SAY`, or other public channels are ignored.
2. **User Confirmation**: Even for trusted channels, the addon no longer starts a route automatically. Instead, it displays a standard World of Warcraft confirmation dialog (`StaticPopup`) showing the sender's name and the destination dungeon. The route only starts if the user explicitly clicks "Yes".

These changes ensure that the user remains in control of their navigation at all times.

---
*PR created automatically by Jules for task [10176835252932361542](https://jules.google.com/task/10176835252932361542) started by @MikeO7*