### PR TITLE
Fix CI/CD version bumping and push logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
 
           # Increment patch version
           # This handles x.y.z format
-          NEW_VERSION=$(echo $VERSION | awk -F. '{$NF = $NF + 1;} OFS="." {print $0}')
+          NEW_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF = $NF + 1; print $0}')
           echo "New version: $NEW_VERSION"
 
           # Update TOC file
-          sed -i "s/## Version: $VERSION/## Version: $NEW_VERSION/" AutoDungeonWaypoint.toc
+          sed -i "s/^## Version: .*/## Version: $NEW_VERSION/" AutoDungeonWaypoint.toc
 
           # Configure git
           git config user.name "github-actions[bot]"
@@ -55,4 +55,4 @@ jobs:
       - name: Push changes
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          git push origin main --tags
+          git push origin HEAD:main --tags


### PR DESCRIPTION
The CI/CD pipeline was failing due to an invalid git tag name (e.g., 'v6 3 2' instead of 'v6.3.2'). This was caused by an error in the awk command that incremented the version number but used the default space separator for output. This PR fixes the awk logic, improves the robustness of the version replacement in the TOC file, and updates the push command to correctly handle the detached HEAD state in GitHub Actions.

Fixes #55

---
*PR created automatically by Jules for task [5737933133255681272](https://jules.google.com/task/5737933133255681272) started by @MikeO7*