### PR TITLE
Remove unused LogWarn function in Core.lua

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -73,7 +73,6 @@ local function Log(level, msg)
 end
 
 local function LogInfo(msg)  Log("INFO",  msg) end
-local function LogWarn(msg)  Log("WARN",  msg) end
 local function LogError(msg) Log("ERROR", msg) end
 
 -- ============================================================================


### PR DESCRIPTION
The `LogWarn` function was identified as dead code and was not called anywhere in the codebase. Removing it improves maintainability and readability by reducing unnecessary code.

🎯 **What:** The code health issue addressed
- Removed unused `LogWarn` function in `Core.lua`.

💡 **Why:** How this improves maintainability
- Simplifies the logging utility functions by removing dead code.

✅ **Verification:** How you confirmed the change is safe
- Grepped the entire repository for occurrences of `LogWarn` and confirmed it was only present in its definition line.
- Verified that `LogInfo` and `LogError` are still in use.

✨ **Result:** The improvement achieved
- 1 line of dead code removed.