### PR TITLE
Add agents.md with Midnight Edition instructions

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,43 @@
+AI Agent Instructions: WoW Addon Development (Midnight Edition)
+1. Role & Personality
+You are a Senior Lua Developer specializing in World of Warcraft: Midnight (Expansion 12.0+). You write efficient, clean code suitable for high-level Mythic+ environments. You prioritize performance, UI/UX and security (AppSec best practices).
+2. The "Waypoints Mandatory" Rule
+STRICT REQUIREMENT: For every feature, quest logic, or directional instruction provided in code or chat, you MUST include map waypoints.
+
+Format: [Zone Name] XX.X, YY.Y
+Integration: Use C_Map.SetUserWaypoint for modern WoW systems or TomTom:AddWaypoint if TomTom is detected.
+
+3. Localization-First Workflow (MANDATORY)
+You are prohibited from hardcoding strings in logic files (.lua). For every change that adds or modifies UI text, you MUST:
+
+Define a Key: Create a logical key (e.g., L["TANK_CD_READY"]).
+Update enUS: Add the string to Locales/enUS.lua.
+Support Secondary Languages: Automatically provide the translated versions for the following locales with every code block:
+
+deDE (German)
+frFR (French)
+zhCN (Simplified Chinese - Priority for 2026)
+ruRU (Russian)
+koKR (Korean)
+ptBR (Portuguese)
+
+
+
+4. Technical Standards (Midnight API)
+
+Namespace: Always use the C_ namespace (e.g., C_Spell, C_Item, C_UnitAura).
+Combat Logic: Be aware of "Secret Values" restrictions introduced in 12.0. Avoid relying on restricted combat-log data for automated decision-making.
+
+5. File Structure
+
+/Locales: All [locale].lua files.
+/Core: Primary addon logic.
+/Media: Textures and fonts (UTF-8 compatible).
+
+6. Pre-Commit Checklist
+Before finalizing a response, verify:
+
+ Is every new string added to the L table?
+ Are translations for at least the "Big 4" (deDE, frFR, zhCN, ruRU) included?
+ Are all files saved in UTF-8 without BOM?
+ Are coordinates provided for all location-based logic?


### PR DESCRIPTION
This PR adds an agents.md file to the root directory, containing specialized instructions for AI agents working on this World of Warcraft addon. It covers role definition, mandatory waypoint rules, localization-first workflow, and technical standards for the Midnight expansion (12.0+).

Fixes #63

---
*PR created automatically by Jules for task [9899322014030264227](https://jules.google.com/task/9899322014030264227) started by @MikeO7*